### PR TITLE
Add a rake task for product feedback

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,8 +20,8 @@ class UserMailer < ApplicationMailer
 		mail(to: recipient_email, subject: "Improve your programming skills and get prepped for your coding interview - become a member of Daily Javascript")
 	end
 
-	def first_product_feedback_email(recipient_email)
-		@recipient_email = recipient_email
-		mail(to: recipient_email, subject: "Help us help you.")
+	def first_product_feedback_email(user_email_address)
+		@recipient_email = user_email_address
+		mail(to: @recipient_email, subject: "Help us help you.")
 	end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -24,4 +24,9 @@ class UserMailer < ApplicationMailer
 		@recipient_email = user_email_address
 		mail(to: @recipient_email, subject: "Help us help you.")
 	end
+
+	def apology_email(user_email_address)
+		@recipient_email = user_email_address
+		mail(to: @recipient_email, subject: "We're sorry.")
+	end
 end

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -66,14 +66,14 @@ class Challenge < ApplicationRecord
 		left_assertions = []
 		right_assertions = []
 		test_function = params.permit(:testFunction)["testFunction"].strip
-		
+
 		3.downto(1) do |x|
 			left_assertions.push(params.permit("assertion#{x}left")["assertion#{x}left"].strip)
 			right_assertions.push(params.permit("assertion#{x}right")["assertion#{x}right"].strip)
 		end
-		
+
 		assertions = ""
-		
+
 		left_assertions.length.times do |x|
 			l_a = left_assertions.pop
 			r_a = right_assertions.pop
@@ -82,7 +82,7 @@ class Challenge < ApplicationRecord
 				assertions = "#{assertions}\n it('will return #{r_a_stripped}', function(){\n expect(#{test_function}(#{l_a})).toEqual(#{r_a})\n });"
 			end
 		end
-		
+
 		full_assertion_statement = "describe('#{test_function}', function(){  #{assertions} \n });"
 		challenge.test_assertions = full_assertion_statement
 		challenge.save

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -37,14 +37,25 @@ class Challenge < ApplicationRecord
 		if challenges.present? && last_user_challenge.present?
 			if DateTime.now >= last_user_challenge.date_sent.at_beginning_of_day.advance(hours: 24)
 				t = Time.now
-				if ( (t >= Time.now.at_beginning_of_day.advance(hours: 11)) && (t <= Time.now.at_beginning_of_day.advance(hours: 17)) ) 
+				if ( (t >= Time.now.at_beginning_of_day.advance(hours: 11)) && (t <= Time.now.at_beginning_of_day.advance(hours: 17)) )
 					mail_next_challenge
 				end
 			end
 		elsif challenges.present?
 			t = Time.now
-			if ( (t >= Time.now.at_beginning_of_day.advance(hours: 11)) && (t <= Time.now.at_beginning_of_day.advance(hours: 17)) ) 
-					mail_next_challenge
+			if ( (t >= Time.now.at_beginning_of_day.advance(hours: 11)) && (t <= Time.now.at_beginning_of_day.advance(hours: 17)) )
+				mail_next_challenge
+			end
+		end
+	end
+
+	def self.check_if_user_challenge_is_seven
+		users = User.all
+		if users.present?
+			users.each do |user|
+				if user.user_challenges.present? && user.user_challenges.last.challenge_id == 7
+					UserMailer.first_product_feedback_email(user.email).deliver_now
+				end
 			end
 		end
 	end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,4 +49,14 @@ def self.get_email_address_only(email)
 	return a.address
 end
 
+def self.send_apology_email
+	users = User.all
+	if users.present?
+		users.each do |user|
+			puts user.email
+			# UserMailer.apology_email(user.email).deliver_now
+		end
+	end
+end
+
 end

--- a/app/views/user_mailer/apology_email.html.erb
+++ b/app/views/user_mailer/apology_email.html.erb
@@ -1,0 +1,19 @@
+<p style="margin: 0 0 1em 0;">
+  Hi <%= @recipient_email %>,
+</p>
+
+<p style="margin: 0 0 1em 0;">
+  Please accept our most sincere apologies for the repeating challenge emails.  We were making system updates and it had an unintended effect on our email list.
+</p>
+
+<p style="margin: 0 0 1em 0;">
+  As a new startup, we're working around the clock trying to make the experience and system better for our users.  There's so much to do and we are a small team.  We will strive to make sure this doesn't happen again.
+</p>
+
+<p style="margin: 0 0 1em 0;">We would like to extend to you an offer to use the test runner that comes in the standard membership for free for one week as a token of our apologies for this mixup.</p>
+
+<p style="margin: 0 0 1em 0;">Just reply back to this email and we will set your next challenge email up with it.</p>
+
+<p style="margin: 0 0 1em 0;">Kind regards,</p>
+
+<p style="margin: 0 0 1em 0;">Abdul </br><span style="font-style: italic;">Founder and Chief Growth Officer</span></p>

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -2,3 +2,8 @@ desc "This task is called by the Heroku scheduler add-on"
 task :email_next_challenge => :environment do
   Challenge.check_if_next_challenge_has_been_sent_then_send_out_next_challenge
 end
+
+desc "This task is also called by the Heroku scheduler add-on"
+task :email_first_product_feedback => :environment do
+  Challenge.check_if_user_challenge_is_seven
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -15,4 +15,8 @@ class UserMailerPreview < ActionMailer::Preview
   def first_product_feedback_email
     UserMailer.with(user: User.first).first_product_feedback_email('yo2@example.com')
   end
+
+  def apology_email
+    UserMailer.with(user: User.first).apology_email('yo2@example.com')
+  end
 end


### PR DESCRIPTION
add rake task to send product feedback email to users who reach email 7.  Followup is to add this as a scheduled heroku job.