### PR TITLE
add lesson model and create schema

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,0 +1,2 @@
+class Lesson < ApplicationRecord
+end

--- a/db/migrate/20200520071514_create_lessons.rb
+++ b/db/migrate/20200520071514_create_lessons.rb
@@ -1,0 +1,12 @@
+class CreateLessons < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lessons do |t|
+      t.string :title
+      t.string :topic
+      t.integer :duration
+      t.text :details
+
+      t.timestamps
+    end
+  end
+end

--- a/test/models/lesson_test.rb
+++ b/test/models/lesson_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LessonTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### Purpose

- What is the context of this pull request?

Right now we use one table for challenges, lessons and tips.  This is the beginning of a two step process to move lessons and tips to their own tables.


🖼️ Before & after screenshots
N/A

💻 Engineer-facing

A lesson will have a title, a topic, the actual details of the lesson and a duration.  The duration is the amount of time it will take to read the lesson.  This is something medium does a lot.  I think it's a nice touch in the emails. 

Here's the algorithm for getting the duration number which we will save as seconds to the db and then do the math on the model to get to minutes inserted where we need to in the view: 

```
Read time is based on the average reading speed of an adult (roughly 275 WPM). We take the total word count of a post and translate it into minutes. Then, we add 12 seconds for each inline image. Boom, read time.
```


### Risks

None

### Testing

None